### PR TITLE
Support separate color var

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ By default, the prompt is green in development, red in production, and yellow el
 
     ConsoleColor::COLORS['production'] = "\e[35m"  # pink
 
+Note that one can set the `CONSOLE_COLOR_ENV` var to override the Rails
+environment:
+
+```
+$ CONSOLE_COLOR_ENV=staging RAILS_ENV=production rails console
+app_name:staging>Rails.env
+=> "production"
+```
+
+This way you can set your staging Rails env to production to mimic that
+configuration but have your prompt reflect that you're using on the staging
+server.
 
 ## Installation
 

--- a/lib/console_color/railtie.rb
+++ b/lib/console_color/railtie.rb
@@ -4,7 +4,12 @@ module ConsoleColor
       def setup(*)
         super
 
-        prompt = "\001#{ConsoleColor::COLORS[Rails.env]}\002#{Rails.application.class.parent_name.downcase}:#{Rails.env}"
+        app_name = Rails.application.class.parent_name.downcase
+        environment = Rails.env
+        color = ConsoleColor::COLORS[environment]
+
+        prompt = "\001#{color}\002#{app_name}:#{environment}"
+
         IRB.conf[:PROMPT][:RAILS_APP] = {
           PROMPT_I: "#{prompt}>\e[0m ",
           PROMPT_N: "#{prompt}>\e[0m ",
@@ -13,6 +18,7 @@ module ConsoleColor
           RETURN: "=> %s\n",
           AUTO_INDENT: true
         }
+
         IRB.conf[:PROMPT_MODE] = :RAILS_APP
       end
     end

--- a/lib/console_color/railtie.rb
+++ b/lib/console_color/railtie.rb
@@ -5,7 +5,7 @@ module ConsoleColor
         super
 
         app_name = Rails.application.class.parent_name.downcase
-        environment = Rails.env
+        environment = ENV.fetch('CONSOLE_COLOR_ENV', Rails.env)
         color = ConsoleColor::COLORS[environment]
 
         prompt = "\001#{color}\002#{app_name}:#{environment}"


### PR DESCRIPTION
This gem assumes that a project has set their RAILS_ENV in staging and production to different values and that's certainly one way to do it, but another way is to set them both to production to ensure that the app setup doesn't drift. This is how we have convection setup, for example.

So this PR just adds a way to override the reliance on Rails.env with a separate ENV var called `CONSOLE_COLOR_ENV`.

Note that the git ignore file actually removes the tests from the repo so I was not able to test this change. I guess I could link my local convection to this gem on my machine to ensure it works as expected, but I would love to get some rspec coverage on this project - what do you think @joeyAghion?