### PR TITLE
require irb before setup

### DIFF
--- a/lib/console_color/railtie.rb
+++ b/lib/console_color/railtie.rb
@@ -28,6 +28,7 @@ module ConsoleColor
     end
 
     config.after_initialize do
+      require "irb"
       class << IRB
         prepend IRBSetup
       end


### PR DESCRIPTION
Recent upgrades highlight the need for `irb` to be required prior to this setup. This fixes:

```
      class << IRB
               ^^^
Did you mean?  ERB
```

This setup is invoked selectively [depending on the environment](https://github.com/joeyAghion/console_color/blob/8f669fcd842a5f6066bb11e95af332d3728d127c/lib/console_color.rb#L3). In case any projects use this in incompatible ways, for now I'm _not_ adding `irb` as an explicit dependency.